### PR TITLE
Fix new names in adapters

### DIFF
--- a/arkworks_adapter/Cargo.toml
+++ b/arkworks_adapter/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pinocchio_vm = { path = "../" }
+pinocchio_lambda_vm = { path = "../" }
 ark-r1cs-std = { version = "^0.3.1"}
 ark-ff = { version = "^0.3.0" }
 ark-relations = { version = "^0.3.0" }

--- a/arkworks_adapter/src/integration_tests.rs
+++ b/arkworks_adapter/src/integration_tests.rs
@@ -1,6 +1,6 @@
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 
-use pinocchio_vm::{
+use pinocchio_lambda_vm::{
     circuits::qap::QuadraticArithmeticProgram as Qap,
     math::elliptic_curve::EllipticCurveElement,
     pinocchio::{

--- a/arkworks_adapter/src/lib.rs
+++ b/arkworks_adapter/src/lib.rs
@@ -8,10 +8,10 @@ use std::ops::Deref;
 use ark_ff::PrimeField;
 use ark_relations::r1cs::ConstraintSystemRef;
 use num_bigint::BigUint;
-use pinocchio_vm::circuits::r1cs::R1CS;
-use pinocchio_vm::config::ORDER_R;
+use pinocchio_lambda_vm::circuits::r1cs::R1CS;
+use pinocchio_lambda_vm::config::ORDER_R;
 
-use pinocchio_vm::math::field_element::FieldElement;
+use pinocchio_lambda_vm::math::field_element::FieldElement;
 type FE = FieldElement<ORDER_R>;
 
 /// Generates an `R1CS` compatible with Lambda Pinocchio from an Arkworks `ConstraintSystemRef`
@@ -130,13 +130,11 @@ mod tests {
         lc,
         r1cs::{ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, SynthesisError},
     };
-    use pinocchio_vm::circuits::{r1cs::Constraint, test_utils};
+    use pinocchio_lambda_vm::circuits::{r1cs::Constraint, test_utils};
 
     // These are tests circuits
     pub struct FullyPrivateMulCircuit {
-        /// Public input
         pub a: Fq,
-        /// Private input
         pub b: Fq,
     }
 
@@ -154,9 +152,7 @@ mod tests {
         }
     }
     pub struct PrivInputPubResultMulCircuit {
-        /// Public input
         pub a: Fq,
-        /// Private input
         pub b: Fq,
     }
 


### PR DESCRIPTION
Fixed project names in Arkworks Adapter

Deleted comments that didn't apply anymore